### PR TITLE
gs-3810-add-support-for-AAc-m4a

### DIFF
--- a/lib/mime_type_list.rb
+++ b/lib/mime_type_list.rb
@@ -19,7 +19,9 @@ module MimeTypeList
 
       def all_mime_types
         %W{
+          audio/aac
           audio/mpeg
+          audio/m4a
           audio/ogg
           audio/wav
         }


### PR DESCRIPTION
[[GS-3810] Add Support for AAC & M4A for Audio Lessons](https://app.asana.com/0/231183600822132/839569079688206/f)

- Add aac and m4a audio types to list of Mime types